### PR TITLE
Use install(1) -d explicitly, avoiding the need for -D

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 CFLAGS=$(OptDbg) -I. $(CWFLAGS)
 
 # STRIP = -s
-INSTALL = /usr/bin/install -D
+INSTALL = /usr/bin/install
 DESTDIR =
 BINDIR  = /usr/bin
 MANDIR  = /usr/share/man
@@ -48,8 +48,9 @@ clean:
 	find . -name core -o -name '*.tmp*' -o -name .tmp -o -name .time | xargs rm -f
 
 install : wiggle wiggle.1
-	$(INSTALL) $(STRIP) -m 755 wiggle $(DESTDIR)$(BINDIR)/wiggle
-	$(INSTALL) -m 644 wiggle.1 $(DESTDIR)$(MAN1DIR)/wiggle.1
+	$(INSTALL) -d $(DESTDIR)$(BINDIR) $(DESTDIR)$(MAN1DIR)
+	$(INSTALL) $(STRIP) -m 755 wiggle $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 644 wiggle.1 $(DESTDIR)$(MAN1DIR)
 
 version : ReadMe.c wiggle.1
 	@rm -f version


### PR DESCRIPTION
-D isn't available on MacOS X by default, but there is not much point
here in using it: we can just create the directories first.
