### PR TITLE
Preserve file mode when using doing --merge --replace

### DIFF
--- a/wiggle.c
+++ b/wiggle.c
@@ -589,6 +589,20 @@ static int do_merge(int argc, char *argv[], int obj, int blanks,
 	if (outfilename)
 		fclose(outfile);
 	else if (replace) {
+		struct stat statbuf;
+
+		if (stat(argv[0], &statbuf) != 0) {
+			fprintf(stderr,
+				"%s: failed to stat original file. - %s\n",
+				Cmd, strerror(errno));
+			return 2;
+		}
+		if (fchmod(fileno(outfile), statbuf.st_mode) != 0) {
+			fprintf(stderr,
+				"%s: failed to change permission of new file. - %s\n",
+				Cmd, strerror(errno));
+			return 2;
+		}
 		fclose(outfile);
 		if (rename(argv[0], orignew) == 0 &&
 		    rename(replacename, argv[0]) == 0)


### PR DESCRIPTION
Just a small issue I noticed with wiggle. I was wondering how come my scripts were loosing their executable bit... When using `wiggle --replace`, it creates the new merged file with 600 permission. (I thought it followed umask but it seems more restrictive in fact.) I would argue it should copy the mode of the original file:

```
ben@f1:~/local/src/kernel-source/scripts/git_sort$ l merge_tool.py
-rwxr-xr-x 1 ben ben 7.2K Aug 18 10:32 merge_tool.py
ben@f1:~/local/src/kernel-source/scripts/git_sort$ wiggle --replace merge_tool.py
1 unresolved conflict found
ben@f1:~/local/src/kernel-source/scripts/git_sort$ l merge_tool.py
-rw------- 1 ben ben 6.4K Aug 18 10:33 merge_tool.py
ben@f1:~/local/src/kernel-source/scripts/git_sort$ umask
0022
```
